### PR TITLE
Added support of YouTube Music playlists

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -70,7 +70,7 @@ exports.buildVideoObject = videoString => {
 };
 
 // Parse the input to a id (or error)
-const PLAYLIST_REGEX = /^(PL|UU|LL)[a-zA-Z0-9-_]{16,32}$/;
+const PLAYLIST_REGEX = /^(PL|UU|LL|RD)[a-zA-Z0-9-_]{16,41}$/;
 const ALBUM_REGEX = /^OLAK5uy_[a-zA-Z0-9-_]{33}$/;
 const CHANNEL_REGEX = /^UC[a-zA-Z0-9-_]{22,32}$/;
 exports.getPlaylistId = (link, callback) => {


### PR DESCRIPTION
Modified REGEX, so YouTube Music playlist links could also pass list query check. 
I've checked many YT Music playlist links. All ids start with **RD**, and they're not longer than 43 symbols.
After that, YT Music id can be used like usual YT playlist's id.