### PR TITLE
Added youtu.be links check and tests

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,7 @@ const QS = require('querystring');
 const PARSE_ITEM = require('./parseItem.js');
 const MINIGET = require('miniget');
 
-const YT_HOSTS = ['www.youtube.com', 'youtube.com', 'music.youtube.com'];
+const YT_HOSTS = ['www.youtube.com', 'youtube.com', 'music.youtube.com', 'youtu.be'];
 const BASE_PLIST_URL = 'https://www.youtube.com/playlist?';
 const BASE_API_URL = 'https://www.youtube.com/youtubei/v1/browse?key=';
 

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -396,11 +396,11 @@ describe('YTPL.getPlaylistID()', () => {
     );
   });
 
-  it('errors for youtu.be links', async() => {
+  it('errors for invalid youtu.be links', async() => {
     const ref = 'https://youtu.be/channel/whatever';
     await ASSERT.rejects(
       YTPL.getPlaylistID(ref),
-      /not a known youtube link/,
+      /Unable to find a id in ./,
     );
   });
 
@@ -487,6 +487,12 @@ describe('YTPL.getPlaylistID()', () => {
     const uploads = await YTPL.getPlaylistID(ref);
     ASSERT.equal(uploads, 'UUqwGaUvq_l0RKszeHhZ5leA');
   });
+
+  it('resolves playlist from youtu.be share link', async() => {
+    const ref = 'https://youtu.be/hIaYzwf0A8A?list=PL37UZ2QfPUvyeqqNi4m_byAjAbSHBIosW';
+    const playlist = await YTPL.getPlaylistID(ref);
+    ASSERT.equal(playlist, 'PL37UZ2QfPUvyeqqNi4m_byAjAbSHBIosW');
+  })
 });
 
 describe('YTPL.validateID()', () => {

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -579,7 +579,7 @@ describe('YTPL.validateID()', () => {
     ASSERT.ok(YTPL.validateID(ref));
   });
 
-  it('true for youtu.be share link', async() => {
+  it('true for youtu.be share link', () => {
     const ref = 'https://youtu.be/hIaYzwf0A8A?list=PL37UZ2QfPUvyeqqNi4m_byAjAbSHBIosW';
     ASSERT.ok(YTPL.validateID(ref));
   });

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -492,7 +492,7 @@ describe('YTPL.getPlaylistID()', () => {
     const ref = 'https://youtu.be/hIaYzwf0A8A?list=PL37UZ2QfPUvyeqqNi4m_byAjAbSHBIosW';
     const playlist = await YTPL.getPlaylistID(ref);
     ASSERT.equal(playlist, 'PL37UZ2QfPUvyeqqNi4m_byAjAbSHBIosW');
-  })
+  });
 });
 
 describe('YTPL.validateID()', () => {

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -578,4 +578,9 @@ describe('YTPL.validateID()', () => {
     const ref = 'https://www.youtube.com/watch?v=ASDF&list=UUqwGaUvq_l0RKszeHhZ5leA';
     ASSERT.ok(YTPL.validateID(ref));
   });
+
+  it('true for youtu.be share link', async() => {
+    const ref = 'https://youtu.be/hIaYzwf0A8A?list=PL37UZ2QfPUvyeqqNi4m_byAjAbSHBIosW';
+    ASSERT.ok(YTPL.validateID(ref));
+  });
 });


### PR DESCRIPTION
Youtube share links use the `youtu.be` domain and these were not recognized by the library because the domain was not considered to be a youtube domain.

Here is an example of a share link containing a playlist id:
`https://youtu.be/hIaYzwf0A8A?list=PL37UZ2QfPUvyeqqNi4m_byAjAbSHBIosW`
This link is now parsed by the library and tests are updated accordingly.

Thanks in advance!